### PR TITLE
feat: add short title

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -55,7 +55,8 @@ export default function Header() {
                     <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-blue-500 via-purple-500 to-pink-500 opacity-0 blur-xl transition-all duration-500 group-hover:opacity-40" />
                   </div>
                   <span className="bg-gradient-to-r from-gray-900 via-blue-800 to-purple-800 bg-clip-text text-xl font-bold text-transparent dark:from-white dark:via-blue-200 dark:to-purple-200">
-                    {t('layout.title')}
+                    <span className="md:hidden">{t('layout.shortTitle')}</span>
+                    <span className="hidden md:inline">{t('layout.title')}</span>
                   </span>
                 </Link>
               </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,6 +27,7 @@
   },
   "layout": {
     "title": "AntFE Developer Community",
+    "shortTitle": "AntFE",
     "menu": "Menu",
     "search": "Search",
     "home": "Home",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -27,6 +27,7 @@
   },
   "layout": {
     "title": "AntFE 程序员社区",
+    "shortTitle": "AntFE",
     "menu": "菜单",
     "search": "搜索",
     "home": "首页",


### PR DESCRIPTION
When the screen width is less than 48rem, the title `"AntFE Developer Community"` will be replaced with the short version `"AntFE"`.

